### PR TITLE
Add Telethon hello world example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+API_ID=
+API_HASH=

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,5 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+# Telethon session files
+*.session

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+This repository is an early exploration of a Telegram monitoring server built with Telethon. It uses a Python script `hello.py` to send a sample message. The project expects API credentials in a `.env` file and must remain non-interactive.
+
+## Guidelines for contributors and Codex agents
+
+- Keep the application non-interactive. Fail fast if required environment variables are missing.
+- Validate Python files with `python3 -m py_compile`.
+- Validate shell scripts with `sh -n`.
+- Dependencies are listed in `requirements.txt`; setup is automated via `setup.sh`.
+- Provide concise commit messages and update documentation when behavior changes.

--- a/README.md
+++ b/README.md
@@ -8,47 +8,35 @@ A simple example script `hello.py` demonstrates sending a `"Hello, Telegram!"` m
 
 ### Usage
 
-Below are example commands for **Bash** and **Fish** shells.
+First, run the setup script to create a virtual environment and install the required packages:
 
-#### Bash
+```shell
+sh setup.sh
+```
 
-1. Create and activate a virtual environment (optional but recommended):
-   ```bash
-   python -m venv .venv
-   source .venv/bin/activate
-   ```
-   Then install dependencies:
-   ```bash
-   pip install telethon
-   ```
-2. Obtain your `API_ID` and `API_HASH` from [my.telegram.org](https://my.telegram.org) and set them as environment variables:
-   ```bash
-   export API_ID=12345
-   export API_HASH=your_api_hash
-   ```
-3. Run the script:
-   ```bash
-   python hello.py
-   ```
+After installation, activate the virtual environment. If you use **Bash** run:
 
-#### Fish
+```bash
+source .venv/bin/activate
+```
 
-1. Create and activate a virtual environment:
-   ```fish
-   python -m venv .venv
-   source .venv/bin/activate.fish
-   ```
-   Then install dependencies:
-   ```fish
-   pip install telethon
-   ```
-2. Set your credentials as universal variables:
-   ```fish
-   set -x API_ID 12345
-   set -x API_HASH your_api_hash
-   ```
-3. Run the script:
-   ```fish
-   python hello.py
-   ```
-   You will be prompted to log in on first run. Afterwards a message is sent to your **Saved Messages**.
+For **Fish** run:
+
+```fish
+source .venv/bin/activate.fish
+```
+
+Next, obtain your `API_ID` and `API_HASH` from [my.telegram.org](https://my.telegram.org) and set them as environment variables:
+
+```shell
+export API_ID=12345
+export API_HASH=your_api_hash
+```
+
+Finally, run the example script:
+
+```shell
+python hello.py
+```
+
+You will be prompted to log in on the first run. Afterwards a message is sent to your **Saved Messages**.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # tg-monitor-mvp
+
+This repository includes small experiments with Telegram using [Telethon](https://github.com/LonamiWebs/Telethon).
+
+## Hello Telethon
+
+A simple example script `hello.py` demonstrates sending a `"Hello, Telegram!"` message to your own account.
+
+### Usage
+
+1. Create and activate a virtual environment (optional but recommended):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+   Then install dependencies:
+   ```bash
+   pip install telethon
+   ```
+2. Obtain your `API_ID` and `API_HASH` from [my.telegram.org](https://my.telegram.org) and set them as environment variables:
+   ```bash
+   export API_ID=12345
+   export API_HASH=your_api_hash
+   ```
+3. Run the script:
+   ```bash
+   python hello.py
+   ```
+   You will be prompted to log in on first run. Afterwards a message is sent to your **Saved Messages**.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A simple example script `hello.py` demonstrates sending a `"Hello, Telegram!"` m
 
 ### Usage
 
+Below are example commands for **Bash** and **Fish** shells.
+
+#### Bash
+
 1. Create and activate a virtual environment (optional but recommended):
    ```bash
    python -m venv .venv
@@ -24,6 +28,27 @@ A simple example script `hello.py` demonstrates sending a `"Hello, Telegram!"` m
    ```
 3. Run the script:
    ```bash
+   python hello.py
+   ```
+
+#### Fish
+
+1. Create and activate a virtual environment:
+   ```fish
+   python -m venv .venv
+   source .venv/bin/activate.fish
+   ```
+   Then install dependencies:
+   ```fish
+   pip install telethon
+   ```
+2. Set your credentials as universal variables:
+   ```fish
+   set -x API_ID 12345
+   set -x API_HASH your_api_hash
+   ```
+3. Run the script:
+   ```fish
    python hello.py
    ```
    You will be prompted to log in on first run. Afterwards a message is sent to your **Saved Messages**.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tg-monitor-mvp
 
-This repository includes small experiments with Telegram using [Telethon](https://github.com/LonamiWebs/Telethon).
+This repository contains the initial building blocks for a future Telegram monitoring server. It currently includes small experiments with [Telethon](https://github.com/LonamiWebs/Telethon).
 
 ## Hello Telethon
 
@@ -39,7 +39,7 @@ API_ID=12345
 API_HASH=your_api_hash
 ```
 
-The example script automatically loads these variables from `.env` when run.
+The example script automatically loads these variables from `.env` when run. It will exit with an error if either value is missing.
 
 Finally, run the example script:
 
@@ -47,4 +47,4 @@ Finally, run the example script:
 python hello.py
 ```
 
-You will be prompted to log in on the first run. Afterwards a message is sent to your **Saved Messages**.
+The script itself is non-interactive. Telethon may still prompt you to sign in on first use. Afterwards a message is sent to your **Saved Messages**.

--- a/README.md
+++ b/README.md
@@ -26,12 +26,20 @@ For **Fish** run:
 source .venv/bin/activate.fish
 ```
 
-Next, obtain your `API_ID` and `API_HASH` from [my.telegram.org](https://my.telegram.org) and set them as environment variables:
+Next, obtain your `API_ID` and `API_HASH` from [my.telegram.org](https://my.telegram.org) and store them in a `.env` file. Start by copying the example:
 
 ```shell
-export API_ID=12345
-export API_HASH=your_api_hash
+cp .env.example .env
 ```
+
+Edit `.env` and fill in your credentials:
+
+```env
+API_ID=12345
+API_HASH=your_api_hash
+```
+
+The example script automatically loads these variables from `.env` when run.
 
 Finally, run the example script:
 

--- a/hello.py
+++ b/hello.py
@@ -1,0 +1,24 @@
+from getpass import getpass
+import os
+from telethon import TelegramClient
+
+api_id = os.environ.get('API_ID')
+if api_id is None:
+    api_id = int(input('Enter your API ID: '))
+else:
+    api_id = int(api_id)
+
+api_hash = os.environ.get('API_HASH')
+if api_hash is None:
+    api_hash = getpass('Enter your API Hash: ')
+
+# This session name will create a file 'hello.session'
+client = TelegramClient('hello', api_id, api_hash)
+
+async def main():
+    # Send a message to yourself ("Saved Messages")
+    await client.send_message('me', 'Hello, Telegram!')
+    print('Message sent successfully!')
+
+with client:
+    client.loop.run_until_complete(main())

--- a/hello.py
+++ b/hello.py
@@ -1,6 +1,11 @@
 from getpass import getpass
 import os
+from pathlib import Path
 from telethon import TelegramClient
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv(Path('.') / '.env')
 
 api_id = os.environ.get('API_ID')
 if api_id is None:

--- a/hello.py
+++ b/hello.py
@@ -1,5 +1,5 @@
-from getpass import getpass
 import os
+import sys
 from pathlib import Path
 from telethon import TelegramClient
 from dotenv import load_dotenv
@@ -8,14 +8,12 @@ from dotenv import load_dotenv
 load_dotenv(Path('.') / '.env')
 
 api_id = os.environ.get('API_ID')
-if api_id is None:
-    api_id = int(input('Enter your API ID: '))
-else:
-    api_id = int(api_id)
-
 api_hash = os.environ.get('API_HASH')
-if api_hash is None:
-    api_hash = getpass('Enter your API Hash: ')
+if not api_id or not api_hash:
+    sys.stderr.write('Error: API_ID and API_HASH must be set in the .env file\n')
+    sys.exit(1)
+
+api_id = int(api_id)
 
 # This session name will create a file 'hello.session'
 client = TelegramClient('hello', api_id, api_hash)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+telethon

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 telethon
+python-dotenv

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+# Setup Python virtual environment and install dependencies
+set -e
+
+# Create virtual environment if it doesn't exist
+if [ ! -d .venv ]; then
+    python -m venv .venv
+fi
+
+# Install dependencies using the venv's pip
+.venv/bin/pip install -r requirements.txt
+
+if [ -n "$FISH_VERSION" ]; then
+    printf '\nTo activate the virtual environment run:\n  source .venv/bin/activate.fish\n'
+else
+    printf '\nTo activate the virtual environment run:\n  source .venv/bin/activate\n'
+fi


### PR DESCRIPTION
## Summary
- add `hello.py` example using Telethon
- document how to run the example in README
- ignore Telethon `.session` files
- recommend using a virtual environment when installing dependencies

## Testing
- `python3 -m py_compile hello.py`


------
https://chatgpt.com/codex/tasks/task_e_685b73ba3ab0832bb7c995f2e9fb0505