### PR TITLE
Fix JSON dump of datetime values

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The default handler prints messages to stdout and writes the most recent one to
 are processed in the order they arrive, batching any new ones while a previous
 batch is handled. Runtime files, including the Telethon session, live inside the
 `runtime/` directory which is ignored by git.
+Datetime values in the JSON dump are encoded as ISO 8601 strings.
 
 ## Setup
 

--- a/tg_monitor/handler.py
+++ b/tg_monitor/handler.py
@@ -22,5 +22,5 @@ class PrintMessageHandler(BaseMessageHandler):
         for m in messages:
             print(f"[{chat}] {m.sender_id}: {m.text}")
             with self.dump_file.open("w", encoding="utf-8") as f:
-                json.dump(m.to_dict(), f, indent=2, ensure_ascii=False)
+                json.dump(m.to_dict(), f, indent=2, ensure_ascii=False, default=str)
                 f.write("\n")


### PR DESCRIPTION
## Summary
- handle datetimes in PrintMessageHandler
- document JSON dump format

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `sh -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_685e79cf5d70832b889379a732333fe0