### PR TITLE
Add configurable GPT model

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ cp config.json.example config.json
 Edit `.env` and provide your `API_ID`, `API_HASH`, and `OPENAI_API_KEY`.
 `GPT_PROMPT_FILE` is optional and can point to a custom prompt file. If unset,
 the built-in prompt `tg_monitor/gpt_prompt.txt` is used.
-`config.json` lists the public chats to monitor.
+`config.json` lists the public chats to monitor and can override the GPT model
+with a `gpt_model` field (defaults to `gpt-3.5-turbo`).
 
 ## Running
 
@@ -45,4 +46,4 @@ python server.py
 ```
 
 The server is non‑interactive. It prints errors to stderr when a configured chat is not found and skips it. If no valid chats remain, the server exits with an error.
-All runtime files, including the Telethon session and the JSON dump, are stored in the `runtime/` directory.
+On startup the chosen GPT model is printed for clarity. All runtime files, including the Telethon session and the JSON dump, are stored in the `runtime/` directory.

--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,5 @@
 {
+  "gpt_model": "gpt-3.5-turbo",
   "chats": [
     "public_chat_name"
   ]

--- a/server.py
+++ b/server.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 from tg_monitor.config import load_config
 from tg_monitor.handler import PrintMessageHandler, GPTLoggingHandler, MultiHandler
 from tg_monitor.monitor import ChatMonitor
+from tg_monitor import gpt_processor
 
 RUNTIME_DIR = Path("runtime")
 
@@ -14,6 +15,9 @@ RUNTIME_DIR = Path("runtime")
 async def main() -> None:
     load_dotenv(Path('.') / '.env')
     config = load_config()
+
+    gpt_processor.set_gpt_model(config.gpt_model)
+    print(f"Using GPT model: {gpt_processor.get_gpt_model()}")
 
     RUNTIME_DIR.mkdir(exist_ok=True)
 

--- a/tg_monitor/config.py
+++ b/tg_monitor/config.py
@@ -10,6 +10,7 @@ class AppConfig:
     api_id: int
     api_hash: str
     chats: List[str]
+    gpt_model: str = "gpt-3.5-turbo"
 
 
 def load_config(path: Path | str = "config.json") -> AppConfig:
@@ -18,10 +19,11 @@ def load_config(path: Path | str = "config.json") -> AppConfig:
         data = json.load(f)
 
     chats = data.get("chats", [])
+    gpt_model = data.get("gpt_model", "gpt-3.5-turbo")
 
     api_id = os.environ.get("API_ID")
     api_hash = os.environ.get("API_HASH")
     if not api_id or not api_hash:
         raise RuntimeError("API_ID and API_HASH must be set in the environment")
 
-    return AppConfig(api_id=int(api_id), api_hash=api_hash, chats=chats)
+    return AppConfig(api_id=int(api_id), api_hash=api_hash, chats=chats, gpt_model=gpt_model)

--- a/tg_monitor/gpt_processor.py
+++ b/tg_monitor/gpt_processor.py
@@ -12,6 +12,8 @@ import openai
 DEFAULT_PROMPT_FILE = Path(__file__).with_name("gpt_prompt.txt")
 PROMPT_FILE = Path(os.environ.get("GPT_PROMPT_FILE", DEFAULT_PROMPT_FILE))
 
+_model = os.environ.get("GPT_MODEL", "gpt-3.5-turbo")
+
 _prompt_cache: str | None = None
 
 
@@ -21,6 +23,17 @@ def _load_prompt() -> str:
         with PROMPT_FILE.open(encoding="utf-8") as f:
             _prompt_cache = f.read()
     return _prompt_cache
+
+
+def set_gpt_model(name: str) -> None:
+    """Override the GPT model used for completions."""
+    global _model
+    _model = name
+
+
+def get_gpt_model() -> str:
+    """Return the GPT model currently in use."""
+    return _model
 
 
 _client: openai.AsyncOpenAI | None = None
@@ -43,7 +56,7 @@ async def process_text_with_gpt(text: str) -> dict[str, Any]:
     prompt = _load_prompt().replace("{{text}}", text)
     try:
         resp = await client.chat.completions.create(
-            model="gpt-3.5-turbo",
+            model=_model,
             messages=[{"role": "user", "content": prompt}],
             temperature=0,
         )


### PR DESCRIPTION
## Summary
- print the GPT model used at startup
- allow overriding the GPT model via `config.json`
- expose helpers to set and query the model
- update documentation and example config

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `sh -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_685e8bea89c8832bbf2e49ff28530f79