### PR TITLE
Add logging infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project provides a minimal Telegram monitoring server built with [Telethon](https://github.com/LonamiWebs/Telethon). It watches the public chats listed in `config.json` and forwards new messages to a pluggable handler.
 
-The default handler prints messages to stdout and writes the most recent one to
+The default handler logs messages to the console and writes the most recent one to
 `runtime/last_message.json` using prettified JSON. A second handler processes
 each message with an OpenAI GPT model and appends the generated JSON
 to `runtime/gpt_results.jsonl`. Messages from the same chat are processed in the
@@ -45,5 +45,10 @@ Start the monitoring server:
 python server.py
 ```
 
-The server is non‑interactive. It prints errors to stderr when a configured chat is not found and skips it. If no valid chats remain, the server exits with an error.
-The GPT logging handler prints the selected model when the server starts. All runtime files, including the Telethon session and the JSON dump, are stored in the `runtime/` directory.
+The server is non‑interactive. Messages and errors are logged to the console and
+`runtime/server.log`. Set the `LOG_LEVEL` environment variable to control the
+verbosity. When a configured chat cannot be found, the error is logged and the
+server continues. If no valid chats remain, the server exits with an error. The
+GPT logging handler logs the selected model when the server starts. All runtime
+files, including the Telethon session and the JSON dump, are stored in the
+`runtime/` directory.

--- a/tg_monitor/handler.py
+++ b/tg_monitor/handler.py
@@ -1,7 +1,10 @@
 from typing import List
 from pathlib import Path
 import json
+import logging
 from telethon.tl.custom.message import Message
+
+logger = logging.getLogger(__name__)
 
 
 class BaseMessageHandler:
@@ -33,7 +36,7 @@ class PrintMessageHandler(BaseMessageHandler):
         for m in messages:
             sender = await m.get_sender()
             username = getattr(sender, "username", None) if sender else None
-            print(f"[{chat}] {username or m.sender_id}: {m.text}")
+            logger.info("[%s] %s: %s", chat, username or m.sender_id, m.text)
 
         last = messages[-1]
         with self.dump_file.open("w", encoding="utf-8") as f:
@@ -48,7 +51,7 @@ class GPTLoggingHandler(BaseMessageHandler):
         self.log_file = Path(log_file)
         self.log_file.parent.mkdir(parents=True, exist_ok=True)
         from .gpt_processor import get_gpt_model
-        print(f"Using GPT model: {get_gpt_model()}")
+        logger.info("Using GPT model: %s", get_gpt_model())
 
     async def handle(self, chat: str, messages: List[Message]) -> None:
         from .gpt_processor import process_text_with_gpt

--- a/tg_monitor/logging.py
+++ b/tg_monitor/logging.py
@@ -1,0 +1,27 @@
+import logging
+import os
+from pathlib import Path
+from logging.handlers import RotatingFileHandler
+
+
+def setup_logging() -> None:
+    """Configure logging for the application."""
+    level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    runtime = Path("runtime")
+    runtime.mkdir(exist_ok=True)
+    log_file = runtime / "server.log"
+
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+
+    file_handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3)
+    file_handler.setFormatter(formatter)
+
+    logging.basicConfig(level=level, handlers=[console_handler, file_handler])
+


### PR DESCRIPTION
## Summary
- add `tg_monitor.logging` with rotating file and console handlers
- log server activity and messages instead of printing
- document log configuration via `LOG_LEVEL`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `sh -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_685e90531f84832b9bd96f4d39635097