### PR TITLE
Add Make webhook handler and integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ API_HASH=
 OPENAI_API_KEY=
 # Optional: override the default GPT prompt path
 # GPT_PROMPT_FILE=
+# Optional: send GPT results to a Make webhook when `relevance` is not
+# `irrelevant`. If unset, the server prints a warning and disables this
+# integration.
+# MAKE_WEBHOOK_URL=

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Edit `.env` and provide your `API_ID`, `API_HASH`, and `OPENAI_API_KEY`.
 the built-in prompt `tg_monitor/gpt_prompt.txt` is used.
 `config.json` lists the public chats to monitor and can override the GPT model
 with a `gpt_model` field (defaults to `gpt-4o`).
+If `MAKE_WEBHOOK_URL` is set, any GPT result whose `relevance` is not
+`irrelevant` is POSTed to that URL. When the variable is missing, the
+server prints a warning and continues without Make integration.
 
 ## Running
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 telethon
 python-dotenv
 openai
+aiohttp

--- a/server.py
+++ b/server.py
@@ -5,7 +5,12 @@ from telethon import TelegramClient
 from dotenv import load_dotenv
 
 from tg_monitor.config import load_config
-from tg_monitor.handler import PrintMessageHandler, GPTLoggingHandler, MultiHandler
+from tg_monitor.handler import (
+    PrintMessageHandler,
+    GPTLoggingHandler,
+    MultiHandler,
+)
+from tg_monitor.make_handler import MakeWebhookHandler
 from tg_monitor.monitor import ChatMonitor
 from tg_monitor import gpt_processor
 
@@ -28,6 +33,7 @@ async def main() -> None:
     handler = MultiHandler(
         PrintMessageHandler(RUNTIME_DIR / 'last_message.json'),
         GPTLoggingHandler(RUNTIME_DIR / 'gpt_results.jsonl'),
+        MakeWebhookHandler(),
     )
 
     async with client:

--- a/tg_monitor/handler.py
+++ b/tg_monitor/handler.py
@@ -55,6 +55,7 @@ class GPTLoggingHandler(BaseMessageHandler):
 
         for m in messages:
             result = await process_text_with_gpt(m.text or "")
+            m.gpt_result = result
             record = {
                 "chat": chat,
                 "message_id": m.id,

--- a/tg_monitor/make_handler.py
+++ b/tg_monitor/make_handler.py
@@ -1,0 +1,39 @@
+import os
+import sys
+from typing import List
+
+import aiohttp
+from telethon.tl.custom.message import Message
+
+from .gpt_processor import process_text_with_gpt
+from .handler import BaseMessageHandler
+
+
+class MakeWebhookHandler(BaseMessageHandler):
+    """Send relevant GPT results to a Make webhook."""
+
+    def __init__(self, webhook_url: str | None = None) -> None:
+        self.webhook_url = webhook_url or os.environ.get("MAKE_WEBHOOK_URL")
+        if not self.webhook_url:
+            print(
+                "Warning: MAKE_WEBHOOK_URL is not set; Make webhook disabled",
+                file=sys.stderr,
+            )
+
+    async def handle(self, chat: str, messages: List[Message]) -> None:
+        if not self.webhook_url:
+            return
+
+        async with aiohttp.ClientSession() as session:
+            for m in messages:
+                result = getattr(m, "gpt_result", None)
+                if result is None:
+                    result = await process_text_with_gpt(m.text or "")
+                    m.gpt_result = result
+                relevance = result.get("relevance")
+                if relevance and relevance != "irrelevant":
+                    await session.post(
+                        self.webhook_url,
+                        json={"chat": chat, "message_id": m.id, "result": result},
+                    )
+


### PR DESCRIPTION
## Summary
- send GPT results to a Make webhook with new `MakeWebhookHandler`
- write GPT results to `m.gpt_result` so other handlers can reuse them
- integrate the new handler in `server.py`
- document `MAKE_WEBHOOK_URL` and require `aiohttp`
- trigger Make webhook for any relevance except `irrelevant`
- warn instead of crashing when `MAKE_WEBHOOK_URL` is missing

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `sh -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_685e91e4f02c832bb181b3006091e0fc